### PR TITLE
Add string support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,9 @@
 [workspace]
 
 members = [ 
-    "passby",
     "header",
     "macros",
+    "passby",
+    "string",
     "tests/simplib",
 ]

--- a/string/Cargo.toml
+++ b/string/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "ffizz-string"
+description = "FFI string implementation"
+repository = "https://github.com/djmitche/ffizz"
+readme = "src/crate-doc.md"
+documentation = "https://docs.rs/ffizz-string"
+license = "MIT"
+version = "0.2.0"
+edition = "2021"
+
+[dependencies]
+ffizz-passby = { path = "../passby" }
+libc = "0.2.131"
+
+[dev-dependencies]
+uuid = { version = "^1.1.2", features = ["v4"] }
+ffizz-header = { path = "../header" }
+libc = "0.2.129"
+
+[package.metadata.docs.rs]
+cargo-args = ["-Zunstable-options", "-Zrustdoc-scrape-examples=examples"]
+

--- a/string/examples/kv.rs
+++ b/string/examples/kv.rs
@@ -1,0 +1,386 @@
+#![warn(unsafe_op_in_unsafe_fn)]
+#![allow(non_camel_case_types)]
+#![allow(unused_unsafe)]
+
+use ffizz_passby::{OpaqueStruct, PassByPointer};
+use ffizz_string::{fz_string_t as kvstore_string_t, FzString};
+use std::collections::HashMap;
+
+ffizz_header::snippet! {
+#[ffizz(name="header", order=0)]
+/// This library implements a simple in-memory key-value store.
+}
+
+pub struct Store {
+    map: HashMap<String, String>,
+}
+
+impl Store {
+    fn new() -> Store {
+        Store {
+            map: HashMap::new(),
+        }
+    }
+
+    fn get(&self, key: &str) -> Option<&str> {
+        self.map.get(key).map(|v| &**v)
+    }
+
+    fn set(&mut self, key: impl Into<String>, value: impl Into<String>) {
+        self.map.insert(key.into(), value.into());
+    }
+
+    fn del(&mut self, key: &str) {
+        self.map.remove(key);
+    }
+}
+
+#[ffizz_header::item]
+#[ffizz(order = 10)]
+/// This opaque pointer type represents a key-value store.
+///
+/// # Safety
+///
+/// In a multi-threaded program, kvstore_t values may be passed from thread to thread, but
+/// _must not_ be accessed concurrently from multiple threads.
+///
+/// Each kvstore_t created with `kvstore_new` must later be freed with `kvstore_free`, and
+/// once freed must not be used again.
+///
+/// Keys and values must be valid UTF-8 strings.
+///
+/// ```c
+/// typedef struct kvstore_t kvstore_t;
+/// ```
+#[allow(non_camel_case_types)]
+#[repr(C)]
+pub struct kvstore_t(pub Store);
+
+impl PassByPointer for kvstore_t {}
+
+#[ffizz_header::item]
+#[ffizz(order = 20)]
+/// Create a new kvstore_t.
+///
+/// # Safety
+///
+/// The returned kvstore_t must be freed with kvstore_free.
+///
+/// ```c
+/// kvstore_t *kvstore_new();
+/// ```
+#[no_mangle]
+pub unsafe extern "C" fn kvstore_new() -> *mut kvstore_t {
+    let store = Store::new();
+    // SAFETY: function docs indicate value must be freed
+    unsafe { kvstore_t(store).return_ptr() }
+}
+
+#[ffizz_header::item]
+#[ffizz(order = 21)]
+/// Free a kvstore_t.
+///
+/// # Safety
+///
+/// The argument must be non-NULL and point to a valid kvstore_t. After this call it is no longer
+/// valid and must not be used.
+///
+/// ```c
+/// void kvstore_free(*kvstore_t);
+/// ```
+#[no_mangle]
+pub unsafe extern "C" fn kvstore_free(store: *mut kvstore_t) {
+    // SAFETY:
+    //  - store is valid and not NULL (see docstring)
+    //  - caller will not use store after this call (see docstring)
+    let store = unsafe { kvstore_t::take_from_ptr_arg(store) };
+    drop(store); // (Rust would do this anyway, but let's be explicit)
+}
+
+#[ffizz_header::item]
+#[ffizz(order = 30)]
+/// Get a value from the kvstore_t.  If the value is not found, the returned string is a Null
+/// variant (test with `kvstore_string_is_null`).
+///
+/// # Safety
+///
+/// The store must be non-NULL and point to a valid kvstore_t.
+///
+/// The key argument must be a valid kvstore_string_t.  The caller must free both the key and the
+/// returned string, if any.
+/// ```c
+/// fz_string_t kvstore_get(kvstore_t *store, kvstore_string_t *key);
+/// ```
+#[no_mangle]
+pub unsafe extern "C" fn kvstore_get(
+    store: *mut kvstore_t,
+    key: *mut kvstore_string_t,
+) -> kvstore_string_t {
+    // SAFETY:
+    // - store is not NULL and valid (see docstring)
+    // - store is valid for the life of this function (documented as not threadsafe)
+    // - store will not be accessed during the life of this function (documented as not threadsafe)
+    let store = &unsafe { kvstore_t::from_ptr_arg_ref(store) }.0;
+    // SAFETY:
+    //  - key must be a valid kvstore_string_t (docstring)
+    //  - key will not be accessed concurrency (type docstring)
+    match unsafe {
+        FzString::with_ref_mut(key, |key| {
+            if let Ok(Some(key)) = key.as_str() {
+                store.get(key)
+            } else {
+                None // Null key or invalid UTF-8 looks the same as key-not-found
+            }
+        })
+    } {
+        // SAFETY:
+        //  - the caller will free the returned value (see docstring)
+        Some(val) => unsafe { FzString::return_val(FzString::String(val.to_string())) },
+        // SAFETY:
+        //  - the caller will free the returned value (see docstring)
+        None => unsafe { FzString::return_val(FzString::Null) },
+    }
+}
+
+#[ffizz_header::item]
+#[ffizz(order = 30)]
+/// Set a value in the kvstore_t, consuming the key and value.  Returns false on error.
+///
+/// # Safety
+///
+/// The store must be non-NULL and point to a valid kvstore_t.
+///
+/// The key and value must both be valid kvstore_string_t values, must not be otherwise accessed
+/// while this function executes, and are invalid when this function returns.
+///
+/// # Note
+///
+/// The kvstore API sometimes invalidates its string arguments and sometimes leaves that
+/// reponsibility to the caller, which could lead to confusion for users of the library. It's done
+/// here for example purposes only!
+///
+/// ```c
+/// bool kvstore_set(kvstore *store, kvstore_string_t *key, kvstore_string_t *value);
+/// ```
+#[no_mangle]
+pub unsafe extern "C" fn kvstore_set(
+    store: *mut kvstore_t,
+    key: *mut kvstore_string_t,
+    val: *mut kvstore_string_t,
+) -> bool {
+    // SAFETY:
+    // - store is not NULL and valid (see docstring)
+    // - store is valid for the life of this function (documented as not threadsafe)
+    // - store will not be accessed during the life of this function (documented as not threadsafe)
+    let store = &mut unsafe { kvstore_t::from_ptr_arg_ref_mut(store) }.0;
+    // SAFETY:
+    //  - key/val are valid kvstore_string_t's (see docstring)
+    //  - key/val are not accessed concurrently (type docstring)
+    //  - key/val are not uesd after function returns (see docstring)
+    let (key, val) = unsafe { (FzString::take(key), FzString::take(val)) };
+
+    if let Ok(Some(key)) = key.into_string() {
+        if let Ok(Some(val)) = val.into_string() {
+            store.set(key, val);
+            return true;
+        }
+    }
+    false
+}
+
+#[ffizz_header::item]
+#[ffizz(order = 30)]
+/// Delete a value from the kvstore_t.  Returns false on error.
+///
+/// # Safety
+///
+/// The store must be non-NULL and point to a valid kvstore_t.
+///
+/// The key must be a valid kvstore_string_t, must not be otherwise accessed while this function
+/// executes, and will remain valid after this function returns.
+/// ```c
+/// bool kvstore_del(kvstore *store, kvstore_string_t *key);
+/// ```
+#[no_mangle]
+pub unsafe extern "C" fn kvstore_del(store: *mut kvstore_t, key: *mut kvstore_string_t) -> bool {
+    // SAFETY:
+    //  - key must be a valid kvstore_string_t (docstring)
+    //  - key will not be accessed concurrency (type docstring)
+    unsafe {
+        FzString::with_ref_mut(key, move |key| {
+            // SAFETY:
+            // - store is not NULL and valid (see docstring)
+            // - store is valid for the life of this function (documented as not threadsafe)
+            // - store will not be accessed during the life of this function (documented as not threadsafe)
+            let store = &mut unsafe { kvstore_t::from_ptr_arg_ref_mut(store) }.0;
+
+            if let Ok(Some(key)) = key.as_str() {
+                store.del(key);
+                true
+            } else {
+                false
+            }
+        })
+    }
+}
+
+ffizz_header::snippet! {
+#[ffizz(name="kvstore_string_t", order=100)]
+/// kvstore_string_t represents a string suitable for use with kvstore, as an opaque
+/// stack-allocated value.
+///
+/// This value can contain either a string or a special "Null" variant indicating there is no
+/// string.  When functions take a `kvstore_string_t*` as an argument, the NULL pointer is treated as
+/// the Null variant.  Note that the Null variant is not necessarily represented as the zero value
+/// of the struct.
+///
+/// # Safety
+///
+/// A kvstore_string_t must always be initialized before it is passed as an argument.  Functions
+/// returning a `kvstore_string_t` return an initialized value.
+///
+/// Each initialized kvstore_string_t must be freed, either by calling kvstore_string_free or by
+/// passing the string to a function which takes ownership of the string.
+///
+/// For a given kvstore_string_t value, API functions must not be called concurrently.  This includes
+/// "read only" functions such as kvstore_string_content.
+///
+/// ```c
+/// typedef struct kvstore_string_t {
+///     uint64_t __reserved[4]
+/// }
+/// ```
+}
+
+// re-export some of the kvstore_string_* as kvstore_string_*
+
+#[ffizz_header::item]
+#[ffizz(order = 110)]
+/// Create a new kvstore_string_t by cloning the content of the given C string.
+///
+/// # Safety
+///
+/// The C string must remain valid and unchanged until after the fz_string_t is freed.  It's
+/// typically easiest to ensure this by using a static string.
+///
+/// ```c
+/// kvstore_string_t kvstore_string_clone(const char *);
+/// ```
+pub use ffizz_string::fz_string_clone as kvstore_string_clone;
+
+#[ffizz_header::item]
+#[ffizz(order = 110)]
+/// Get the content of the string as a regular C string.
+///
+/// A string contianing NUL bytes will result in a NULL return value.  In general, prefer
+/// `kvstore_string_content_with_len` except when it's certain that the string is NUL-free.
+///
+/// The Null variant also results in a NULL return value.
+///
+/// This function takes the kvstore_string_t by pointer because it may be modified in-place to add a NUL
+/// terminator.  The pointer must not be NULL.
+///
+/// # Safety
+///
+/// The returned string is "borrowed" and remains valid only until the kvstore_string_t is freed or
+/// passed to any other API function.
+pub use ffizz_string::fz_string_content as kvstore_string_content;
+
+#[ffizz_header::item]
+#[ffizz(order = 110)]
+/// Free a kvstore_string_t.
+///
+/// # Safety
+///
+/// The string must not be used after this function returns, and must not be freed more than once.
+/// It is safe to free Null-variant strings.
+///
+/// ```c
+/// kvstore_string_free(kvstore_string_t *);
+/// ```
+pub use ffizz_string::fz_string_free as kvstore_string_free;
+
+#[ffizz_header::item]
+#[ffizz(order = 110)]
+/// Determine whether the given kvstore_string_t is a Null variant.
+///
+/// ```c
+/// bool kvstore_string_is_null(kvstore_string_t *);
+/// ```
+pub use ffizz_string::fz_string_is_null as kvstore_string_is_null;
+
+// Calling a C API from Rust is tricky, and not what ffizz is about.  This section serves as a
+// test of the example code above, with equivalent C code included in comments.
+fn main() {
+    // kvstore_t *store = kvstore_new();
+    let store = unsafe { kvstore_new() };
+
+    /// Clone a Rust string into an kvstore_string_t
+    fn fzstr(s: &str) -> kvstore_string_t {
+        use std::ffi::CString;
+        let cstr = CString::new(s).unwrap();
+        unsafe { kvstore_string_clone(cstr.as_ptr()) }
+    }
+
+    /// Get a Rust &str containing the data in an kvstore_string_t
+    fn rstr(fzs: &mut kvstore_string_t) -> &str {
+        use std::ffi::CStr;
+        let content =
+            unsafe { CStr::from_ptr(kvstore_string_content(fzs as *mut kvstore_string_t)) };
+        content.to_str().unwrap()
+    }
+
+    // kvstore_string_t key = kvstore_string_clone("a-key");
+    let mut key = fzstr("a-key");
+
+    // kvstore_string_t val = kvstore_get(store, key)
+    let mut val = unsafe { kvstore_get(store, &mut key as *mut kvstore_string_t) };
+
+    // assert(kvstore_string_is_null(val));
+    assert!(unsafe { kvstore_string_is_null(&val as *const kvstore_string_t) });
+
+    // kvstore_string_free(val);
+    unsafe { kvstore_string_free(&mut val as *mut kvstore_string_t) };
+
+    // val = kvstore_string_clone("a-val");
+    let mut val = fzstr("a-val");
+
+    // assert(kvstore_set(store, key, val));
+    assert!(unsafe {
+        kvstore_set(
+            store,
+            &mut key as *mut kvstore_string_t,
+            &mut val as *mut kvstore_string_t,
+        )
+    });
+
+    // key = kvstore_string_clone("a-key");
+    let mut key = fzstr("a-key");
+
+    // val = kvstore_get(store, key)
+    let mut val = unsafe { kvstore_get(store, &mut key as *mut kvstore_string_t) };
+
+    // assert(0 == strcmp(kvstore_string_content(val), "a-val"));
+    assert_eq!(rstr(&mut val), "a-val");
+
+    // kvstore_string_free(val);
+    unsafe { kvstore_string_free(&mut val as *mut kvstore_string_t) };
+
+    // assert(kvstore_del(store, key));
+    assert!(unsafe { kvstore_del(store, &mut key as *mut kvstore_string_t,) });
+
+    // val = kvstore_get(store, key)
+    let mut val = unsafe { kvstore_get(store, &mut key as *mut kvstore_string_t) };
+
+    // assert(kvstore_string_is_null(val));
+    assert!(unsafe { kvstore_string_is_null(&val as *const kvstore_string_t) });
+
+    // kvstore_string_free(key);
+    unsafe { kvstore_string_free(&mut key as *mut kvstore_string_t) };
+
+    // kvstore_string_free(val);
+    unsafe { kvstore_string_free(&mut val as *mut kvstore_string_t) };
+
+    // kvstore_free(store);
+    unsafe { kvstore_free(store) };
+}

--- a/string/src/crate-doc.md
+++ b/string/src/crate-doc.md
@@ -1,0 +1,65 @@
+This crate provides a string abstraction that is convenient to use from both Rust and C.
+It provides a way to pass strings into Rust functions and to return strings to C, with clear rules for ownership.
+
+## Usage
+
+Expose the C type `fz_string_t` in your C header as a struct with the same structure as that in the [`fz_string_t`] docstring.
+This is large enough to hold the [`FzString`] type, and ensures the C compiler will properly align the value.
+
+You may call the type whatever you like.
+Type names are erased in the C ABI, so it's fine to write a Rust declaration using `fz_string_t` and equivalent C declaration using `your_name_here_t`.
+You may also rename the Rust type with `use ffizz_string::fz_string_t as ..`, if you prefer.
+
+### As an Argument
+
+Define your `extern "C"` function to take a `*mut fz_string_t` argument:
+
+```ignore
+pub unsafe extern "C" fn is_a_color_name(name: *mut fz_string_t) -> bool { .. };
+```
+
+Then use one of the FzString methods to handle the string value.
+As standard practice, address each of the items listed in the "Safety" section of each unsafe method you call.
+For example:
+
+```ignore
+// SAFETY:
+//  - name is not NULL (see docstring)
+//  - no other thread will mutate name (type is documented as not threadsafe)
+unsafe {
+    FzString::with_ref(name, |name| {
+        if let Some(name) = name.as_str() {
+            return Colors::from_str(name).is_some();
+        }
+        false // invalid UTF-8 is _not_ a color name
+    })
+}
+```
+
+### As a Return Value
+
+To return a string, define your `extern "C"` function to return an `fz_string_t`:
+```ignore
+pub unsafe extern "C" fn favorite_color() -> fz_string_t { .. }
+```
+
+Then use `FzString::return_val` to return the value:
+```ignore
+// SAFETY:
+//  - caller will free the returned string (see docstring)
+unsafe {
+    return FzString::return_val(color);
+}
+```
+
+## Example
+
+See the `kv` example in this crate for a worked example of a simple library using `ffizz_string`.
+
+## Performance
+
+The implementation is general-purpose, and may result in more allocations or string copies than strictly necessary.
+This is particularly true if the Rust implementation immediately converts `FzString` into `std::string::String`.
+This conversion brings great simplicity, but involves an allocation and a copy of the string.
+
+In situations where API performance is critical, it may be preferable to create a purpose-specific string implementation, perhaps inspired by this crate.

--- a/string/src/error.rs
+++ b/string/src/error.rs
@@ -1,0 +1,28 @@
+use std::error::Error;
+use std::fmt;
+
+/// InvalidUTF8Error indicates that the string contains invalid UTF-8 and could not be
+/// represented as a Rust string.
+#[derive(Eq, PartialEq, Debug)]
+pub struct InvalidUTF8Error;
+
+impl fmt::Display for InvalidUTF8Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "value contains invalid UTF-8 bytes")
+    }
+}
+
+impl Error for InvalidUTF8Error {}
+
+/// EmbeddedNulError indicates that the string contains embedded NUL bytes and
+/// could not be represented as a C string.
+#[derive(Eq, PartialEq, Debug)]
+pub struct EmbeddedNulError;
+
+impl fmt::Display for EmbeddedNulError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "value contains embedded NUL bytes")
+    }
+}
+
+impl Error for EmbeddedNulError {}

--- a/string/src/fzstring.rs
+++ b/string/src/fzstring.rs
@@ -1,0 +1,599 @@
+use crate::{EmbeddedNulError, InvalidUTF8Error};
+use ffizz_passby::OpaqueStruct;
+use std::ffi::{CStr, CString};
+
+/// A FzString carries a single string between Rust and C code, represented from the C side as
+/// an opaque struct.
+///
+/// The two environments carry some different requirements: C generally requires that strings be
+/// NUL-terminated, while Rust requires that strings be valid UTF-8.  Rust also permits NUL
+/// characters in the middle of a string.
+///
+/// This type accepts whatever kind of data it receives without error, and converts -- potentially
+/// with an error -- when output of a different kind is required.
+///
+/// FzStrings also have a special "Null" state, similar to the None variant of Option.  Rust code
+/// should use `.unwrap()` where the Null variant is not allowed.  For user convenience, a NULL
+/// pointer is treated as a pointer to the Null variant wherever a pointer is accepted.  Note that
+/// the Null variant is not necessarily represented with an all-zero byte pattern.
+///
+/// A FzString points to allocated memory, and must be freed to avoid memory leaks.
+#[derive(PartialEq, Eq, Debug)]
+pub enum FzString<'a> {
+    /// An un-set FzString.
+    Null,
+    /// An owned Rust string (not NUL-terminated, valid UTF-8).
+    String(String),
+    /// An owned C String (NUL-terminated, may contain invalid UTF-8).
+    CString(CString),
+    /// A borrowed C string.
+    CStr(&'a CStr),
+    /// An owned bunch of bytes (not NUL-terminated, may contain invalid UTF-8).
+    Bytes(Vec<u8>),
+}
+
+/// fz_string_t represents a string suitable for use with this crate, as an opaque stack-allocated
+/// value.
+///
+/// This value can contain either a string or a special "Null" variant indicating there is no
+/// string.  When functions take a `fz_string_t*` as an argument, the NULL pointer is treated as
+/// the Null variant.  Note that the Null variant is not necessarily represented as the zero value
+/// of the struct.
+///
+/// # Safety
+///
+/// A fz_string_t must always be initialized before it is passed as an argument.  Functions
+/// returning a `fz_string_t` return an initialized value.
+///
+/// Each initialized fz_string_t must be freed, either by calling fz_string_free or by
+/// passing the string to a function which takes ownership of the string.
+///
+/// For a given fz_string_t value, API functions must not be called concurrently.  This includes
+/// "read only" functions such as fz_string_content.
+///
+/// ```c
+/// typedef struct fz_string_t {
+///     uint64_t __reserved[4]
+/// }
+/// ```
+#[repr(C)]
+pub struct fz_string_t {
+    // size for a determinant, pointer, length, and capacity; conservatively assuming
+    // 64 bits for each, and assuring 64-bit alignment.
+    __reserved: [u64; 4],
+}
+
+impl OpaqueStruct for FzString<'_> {
+    type CType = fz_string_t;
+
+    fn null_value() -> Self {
+        FzString::Null
+    }
+}
+
+impl Default for FzString<'_> {
+    fn default() -> Self {
+        FzString::Null
+    }
+}
+
+impl<'a> FzString<'a> {
+    /// Check if this is a Null FzString.
+    pub fn is_null(&self) -> bool {
+        matches!(self, Self::Null)
+    }
+
+    /// Convert this value to `&str`.
+    ///
+    /// If required, the FzString is converted in-place to a String variant. If this conversion
+    /// fails because the content is not valid UTF-8, an error is returned.
+    ///
+    /// The Null FzString is represented as None.
+    pub fn as_str(&mut self) -> Result<Option<&str>, InvalidUTF8Error> {
+        // first, convert in-place from bytes
+        if let FzString::Bytes(_) = self {
+            self.bytes_to_string()?;
+        }
+
+        Ok(match self {
+            FzString::CString(cstring) => {
+                Some(cstring.as_c_str().to_str().map_err(|_| InvalidUTF8Error)?)
+            }
+            FzString::CStr(cstr) => Some(cstr.to_str().map_err(|_| InvalidUTF8Error)?),
+            FzString::String(ref string) => Some(string.as_ref()),
+            FzString::Bytes(_) => unreachable!(), // handled above
+            FzString::Null => None,
+        })
+    }
+
+    /// Convert this value to a CStr: a slice of bytes containing a valid, NUL-terminated C string.
+    ///
+    /// If required, the FzString is converted in-place to a CString variant. If this conversion
+    /// fails because the content contains embedded NUL characters, an error is returned.
+    ///
+    /// The Null FzString is represented as None.
+    pub fn as_cstr(&mut self) -> Result<Option<&CStr>, EmbeddedNulError> {
+        // first, convert in-place from String or Bytes (neither of which have a NUL terminator)
+        match self {
+            FzString::String(_) => self.string_to_cstring()?,
+            FzString::Bytes(_) => self.bytes_to_cstring()?,
+            _ => {}
+        }
+
+        Ok(match self {
+            FzString::CString(cstring) => Some(cstring.as_c_str()),
+            FzString::CStr(cstr) => Some(cstr),
+            FzString::String(_) => unreachable!(), // handled above
+            FzString::Bytes(_) => unreachable!(),  // handled above
+            FzString::Null => None,
+        })
+    }
+
+    /// Consume this FzString and return an equivalent String.
+    ///
+    /// As with `as_str`, the FzString is converted in-place, and this conversion can fail.  In the
+    /// failure case, the original data is lost.
+    ///
+    /// The Null varaiant is represented as None.
+    pub fn into_string(mut self) -> Result<Option<String>, InvalidUTF8Error> {
+        // first, convert in-place from bytes
+        if let FzString::Bytes(_) = self {
+            self.bytes_to_string()?;
+        }
+
+        Ok(match self {
+            FzString::CString(cstring) => {
+                Some(cstring.into_string().map_err(|_| InvalidUTF8Error)?)
+            }
+            FzString::CStr(cstr) => Some(
+                cstr.to_str()
+                    .map(|s| s.to_string())
+                    .map_err(|_| InvalidUTF8Error)?,
+            ),
+            FzString::String(string) => Some(string),
+            FzString::Bytes(_) => unreachable!(), // handled above
+            FzString::Null => None,
+        })
+    }
+
+    /// Get the slice of bytes representing the content of this value, not including any NUL
+    /// terminator.
+    ///
+    /// Any variant can be represented as a byte slice, so this method does not mutate the
+    /// FzString and cannot fail.
+    ///
+    /// The Null variant is represented as None.
+    pub fn as_bytes(&self) -> Option<&[u8]> {
+        match self {
+            FzString::CString(cstring) => Some(cstring.as_bytes()),
+            FzString::CStr(cstr) => Some(cstr.to_bytes()),
+            FzString::String(string) => Some(string.as_bytes()),
+            FzString::Bytes(bytes) => Some(bytes.as_ref()),
+            FzString::Null => None,
+        }
+    }
+
+    /// Convert the FzString, in place, from a Bytes to String variant, returning None if
+    /// the bytes do not contain valid UTF-8.
+    fn bytes_to_string(&mut self) -> Result<(), InvalidUTF8Error> {
+        if let FzString::Bytes(bytes) = self {
+            // first, check for invalid UTF-8
+            if std::str::from_utf8(bytes).is_err() {
+                return Err(InvalidUTF8Error);
+            }
+            // take ownership of the bytes Vec
+            let bytes = std::mem::take(bytes);
+            // SAFETY: we just checked this..
+            let string = unsafe { String::from_utf8_unchecked(bytes) };
+            *self = FzString::String(string);
+            Ok(())
+        } else {
+            unreachable!()
+        }
+    }
+
+    /// Convert the FxString, in place, from a Bytes to CString variant, returning None if the
+    /// string contains embedded NULs.
+    ///
+    /// Panics if self is not Bytes.
+    fn bytes_to_cstring(&mut self) -> Result<(), EmbeddedNulError> {
+        if let FzString::Bytes(bytes) = self {
+            // first, check for NUL bytes within the sequence
+            if has_nul_bytes(bytes) {
+                return Err(EmbeddedNulError);
+            }
+            // take ownership of the bytes Vec
+            let bytes = std::mem::take(bytes);
+            // SAFETY: we just checked for NUL bytes
+            let cstring = unsafe { CString::from_vec_unchecked(bytes) };
+            *self = FzString::CString(cstring);
+            Ok(())
+        } else {
+            unreachable!()
+        }
+    }
+
+    /// Convert the FzString, in place, from a String to CString variant, returning None if the
+    /// string contains embedded NULs.
+    ///
+    /// Panics if self is not String.
+    fn string_to_cstring(&mut self) -> Result<(), EmbeddedNulError> {
+        if let FzString::String(string) = self {
+            // first, check for NUL bytes within the sequence
+            if has_nul_bytes(string.as_bytes()) {
+                return Err(EmbeddedNulError);
+            }
+            // take ownership of the string
+            let string = std::mem::take(string);
+            // SAFETY: we just checked for NUL bytes
+            let cstring = unsafe { CString::from_vec_unchecked(string.into_bytes()) };
+            *self = FzString::CString(cstring);
+            Ok(())
+        } else {
+            unreachable!()
+        }
+    }
+}
+
+impl From<String> for FzString<'static> {
+    fn from(string: String) -> FzString<'static> {
+        FzString::String(string)
+    }
+}
+
+impl From<&str> for FzString<'static> {
+    fn from(string: &str) -> FzString<'static> {
+        FzString::String(string.to_string())
+    }
+}
+
+impl From<Vec<u8>> for FzString<'static> {
+    fn from(bytes: Vec<u8>) -> FzString<'static> {
+        FzString::Bytes(bytes)
+    }
+}
+
+impl From<&[u8]> for FzString<'static> {
+    fn from(bytes: &[u8]) -> FzString<'static> {
+        FzString::Bytes(bytes.to_vec())
+    }
+}
+
+impl From<Option<String>> for FzString<'static> {
+    fn from(string: Option<String>) -> FzString<'static> {
+        match string {
+            Some(string) => FzString::String(string),
+            None => FzString::Null,
+        }
+    }
+}
+
+impl From<Option<&str>> for FzString<'static> {
+    fn from(string: Option<&str>) -> FzString<'static> {
+        match string {
+            Some(string) => FzString::String(string.to_string()),
+            None => FzString::Null,
+        }
+    }
+}
+
+impl From<Option<Vec<u8>>> for FzString<'static> {
+    fn from(bytes: Option<Vec<u8>>) -> FzString<'static> {
+        match bytes {
+            Some(bytes) => FzString::Bytes(bytes),
+            None => FzString::Null,
+        }
+    }
+}
+
+impl From<Option<&[u8]>> for FzString<'static> {
+    fn from(bytes: Option<&[u8]>) -> FzString<'static> {
+        match bytes {
+            Some(bytes) => FzString::Bytes(bytes.to_vec()),
+            None => FzString::Null,
+        }
+    }
+}
+
+fn has_nul_bytes(bytes: &[u8]) -> bool {
+    bytes.iter().any(|c| *c == b'\0')
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    const INVALID_UTF8: &[u8] = b"abc\xf0\x28\x8c\x28";
+
+    fn make_cstring() -> FzString<'static> {
+        FzString::CString(CString::new("a string").unwrap())
+    }
+
+    fn make_cstr() -> FzString<'static> {
+        let cstr = CStr::from_bytes_with_nul(b"a string\0").unwrap();
+        FzString::CStr(cstr)
+    }
+
+    fn make_string() -> FzString<'static> {
+        "a string".into()
+    }
+
+    fn make_string_with_nul() -> FzString<'static> {
+        "a \0 nul!".into()
+    }
+
+    fn make_invalid_bytes() -> FzString<'static> {
+        INVALID_UTF8.into()
+    }
+
+    fn make_nul_bytes() -> FzString<'static> {
+        (&b"abc\0123"[..]).into()
+    }
+
+    fn make_bytes() -> FzString<'static> {
+        (&b"bytes"[..]).into()
+    }
+
+    fn make_null() -> FzString<'static> {
+        FzString::Null
+    }
+
+    fn cstr(s: &str) -> &CStr {
+        CStr::from_bytes_with_nul(s.as_bytes()).unwrap()
+    }
+
+    // as_str
+
+    #[test]
+    fn as_str_cstring() {
+        assert_eq!(make_cstring().as_str().unwrap(), Some("a string"));
+    }
+
+    #[test]
+    fn as_str_cstr() {
+        assert_eq!(make_cstr().as_str().unwrap(), Some("a string"));
+    }
+
+    #[test]
+    fn as_str_string() {
+        assert_eq!(make_string().as_str().unwrap(), Some("a string"));
+    }
+
+    #[test]
+    fn as_str_string_with_nul() {
+        assert_eq!(make_string_with_nul().as_str().unwrap(), Some("a \0 nul!"));
+    }
+
+    #[test]
+    fn as_str_invalid_bytes() {
+        assert_eq!(make_invalid_bytes().as_str().unwrap_err(), InvalidUTF8Error);
+    }
+
+    #[test]
+    fn as_str_nul_bytes() {
+        assert_eq!(make_nul_bytes().as_str().unwrap(), Some("abc\0123"));
+    }
+
+    #[test]
+    fn as_str_valid_bytes() {
+        assert_eq!(make_bytes().as_str().unwrap(), Some("bytes"));
+    }
+
+    #[test]
+    fn as_str_null() {
+        assert!(make_null().as_str().unwrap().is_none());
+    }
+
+    // as_cstr
+
+    #[test]
+    fn as_cstr_cstring() {
+        assert_eq!(make_cstring().as_cstr().unwrap(), Some(cstr("a string\0")));
+    }
+
+    #[test]
+    fn as_cstr_cstr() {
+        assert_eq!(make_cstr().as_cstr().unwrap(), Some(cstr("a string\0")));
+    }
+
+    #[test]
+    fn as_cstr_string() {
+        assert_eq!(make_string().as_cstr().unwrap(), Some(cstr("a string\0")));
+    }
+
+    #[test]
+    fn as_cstr_string_with_nul() {
+        assert_eq!(
+            make_string_with_nul().as_cstr().unwrap_err(),
+            EmbeddedNulError
+        );
+    }
+
+    #[test]
+    fn as_cstr_invalid_bytes() {
+        let expected = CString::new(INVALID_UTF8).unwrap();
+        assert_eq!(
+            make_invalid_bytes().as_cstr().unwrap(),
+            Some(expected.as_c_str())
+        );
+    }
+
+    #[test]
+    fn as_cstr_nul_bytes() {
+        assert_eq!(make_nul_bytes().as_cstr().unwrap_err(), EmbeddedNulError);
+    }
+
+    #[test]
+    fn as_cstr_valid_bytes() {
+        assert_eq!(make_bytes().as_cstr().unwrap(), Some(cstr("bytes\0")));
+    }
+
+    #[test]
+    fn as_cstr_null() {
+        assert_eq!(make_null().as_cstr().unwrap(), None);
+    }
+
+    // into_string
+
+    #[test]
+    fn into_string_cstring() {
+        assert_eq!(
+            make_cstring().into_string().unwrap(),
+            Some(String::from("a string"))
+        );
+    }
+
+    #[test]
+    fn into_string_cstr() {
+        assert_eq!(
+            make_cstr().into_string().unwrap(),
+            Some(String::from("a string"))
+        );
+    }
+
+    #[test]
+    fn into_string_string() {
+        assert_eq!(
+            make_string().into_string().unwrap(),
+            Some(String::from("a string"))
+        );
+    }
+
+    #[test]
+    fn into_string_string_with_nul() {
+        assert_eq!(
+            make_string_with_nul().into_string().unwrap(),
+            Some(String::from("a \0 nul!"))
+        )
+    }
+
+    #[test]
+    fn into_string_invalid_bytes() {
+        assert_eq!(
+            make_invalid_bytes().into_string().unwrap_err(),
+            InvalidUTF8Error
+        );
+    }
+
+    #[test]
+    fn into_string_nul_bytes() {
+        assert_eq!(
+            make_nul_bytes().into_string().unwrap(),
+            Some(String::from("abc\0123"))
+        );
+    }
+
+    #[test]
+    fn into_string_valid_bytes() {
+        assert_eq!(
+            make_bytes().into_string().unwrap(),
+            Some(String::from("bytes"))
+        );
+    }
+
+    #[test]
+    fn into_string_null() {
+        assert_eq!(make_null().into_string().unwrap(), None);
+    }
+
+    // as_bytes
+
+    #[test]
+    fn as_bytes_cstring() {
+        assert_eq!(make_cstring().as_bytes().unwrap(), b"a string");
+    }
+
+    #[test]
+    fn as_bytes_cstr() {
+        assert_eq!(make_cstr().as_bytes().unwrap(), b"a string");
+    }
+
+    #[test]
+    fn as_bytes_string() {
+        assert_eq!(make_string().as_bytes().unwrap(), b"a string");
+    }
+
+    #[test]
+    fn as_bytes_string_with_nul() {
+        assert_eq!(make_string_with_nul().as_bytes().unwrap(), b"a \0 nul!");
+    }
+
+    #[test]
+    fn as_bytes_invalid_bytes() {
+        assert_eq!(make_invalid_bytes().as_bytes().unwrap(), INVALID_UTF8);
+    }
+
+    #[test]
+    fn as_bytes_null_bytes() {
+        assert_eq!(make_nul_bytes().as_bytes().unwrap(), b"abc\0123");
+    }
+
+    #[test]
+    fn as_bytes_null() {
+        assert_eq!(make_null().as_bytes(), None);
+    }
+
+    // From<..>
+
+    #[test]
+    fn from_string() {
+        assert_eq!(
+            FzString::from(String::from("hello")),
+            FzString::String(String::from("hello"))
+        );
+    }
+
+    #[test]
+    fn from_str() {
+        assert_eq!(
+            FzString::from("hello"),
+            FzString::String(String::from("hello"))
+        );
+    }
+
+    #[test]
+    fn from_vec() {
+        assert_eq!(FzString::from(vec![1u8, 2u8]), FzString::Bytes(vec![1, 2]));
+    }
+
+    #[test]
+    fn from_bytes() {
+        assert_eq!(FzString::from(INVALID_UTF8), make_invalid_bytes());
+    }
+
+    #[test]
+    fn from_option_string() {
+        assert_eq!(FzString::from(None as Option<String>), FzString::Null);
+        assert_eq!(
+            FzString::from(Some(String::from("hello"))),
+            FzString::String(String::from("hello")),
+        );
+    }
+
+    #[test]
+    fn from_option_str() {
+        assert_eq!(FzString::from(None as Option<&str>), FzString::Null);
+        assert_eq!(
+            FzString::from(Some("hello")),
+            FzString::String(String::from("hello")),
+        );
+    }
+
+    #[test]
+    fn from_option_vec() {
+        assert_eq!(FzString::from(None as Option<Vec<u8>>), FzString::Null);
+        assert_eq!(
+            FzString::from(Some(vec![1u8, 2u8])),
+            FzString::Bytes(vec![1, 2])
+        );
+    }
+
+    #[test]
+    fn from_option_bytes() {
+        assert_eq!(FzString::from(None as Option<&[u8]>), FzString::Null);
+        assert_eq!(
+            FzString::from(Some(INVALID_UTF8)),
+            FzString::Bytes(INVALID_UTF8.into())
+        );
+    }
+}

--- a/string/src/lib.rs
+++ b/string/src/lib.rs
@@ -1,0 +1,12 @@
+#![warn(unsafe_op_in_unsafe_fn)]
+#![allow(non_camel_case_types)]
+#![allow(unused_unsafe)]
+#![doc = include_str!("crate-doc.md")]
+
+mod error;
+mod fzstring;
+mod utilfns;
+
+pub use error::*;
+pub use fzstring::{fz_string_t, FzString};
+pub use utilfns::*;

--- a/string/src/utilfns.rs
+++ b/string/src/utilfns.rs
@@ -1,0 +1,396 @@
+use crate::{fz_string_t, FzString};
+use ffizz_passby::OpaqueStruct;
+use libc::c_char;
+use std::ffi::{CStr, CString};
+
+/// Create a new fz_string_t containing a pointer to the given C string.
+///
+/// # Safety
+///
+/// The C string must remain valid and unchanged until after the fz_string_t is freed.  It's
+/// typically easiest to ensure this by using a static string.
+///
+/// ```c
+/// fz_string_t fz_string_borrow(const char *);
+/// ```
+#[no_mangle]
+pub unsafe extern "C" fn fz_string_borrow(cstr: *const c_char) -> fz_string_t {
+    debug_assert!(!cstr.is_null());
+    // SAFETY:
+    //  - cstr is not NULL (promised by caller, verified by assertion)
+    //  - cstr's lifetime exceeds that of the fz_string_t (promised by caller)
+    //  - cstr contains a valid NUL terminator (promised by caller)
+    //  - cstr's content will not change before it is destroyed (promised by caller)
+    let cstr: &CStr = unsafe { CStr::from_ptr(cstr) };
+    // SAFETY:
+    //  - caller promises to free this string
+    unsafe { FzString::return_val(FzString::CStr(cstr)) }
+}
+
+#[allow(clippy::missing_safety_doc)] // not actually terribly unsafe
+/// Create a new, null fz_string_t.  Note that this is _not_ the zero value of fz_string_t.
+///
+/// ```c
+/// fz_string_t fz_string_null();
+/// ```
+#[no_mangle]
+pub unsafe extern "C" fn fz_string_null() -> fz_string_t {
+    // SAFETY:
+    //  - caller promises to free this string
+    unsafe { FzString::return_val(FzString::Null) }
+}
+
+/// Create a new fz_string_t by cloning the content of the given C string.  The resulting fz_string_t
+/// is independent of the given string.
+///
+/// # Safety
+///
+/// The given pointer must not be NULL.
+///
+/// ```c
+/// fz_string_t fz_string_clone(const char *);
+/// ```
+#[no_mangle]
+pub unsafe extern "C" fn fz_string_clone(cstr: *const c_char) -> fz_string_t {
+    debug_assert!(!cstr.is_null());
+    // SAFETY:
+    //  - cstr is not NULL (promised by caller, verified by assertion)
+    //  - cstr's lifetime exceeds that of this function (by C convention)
+    //  - cstr contains a valid NUL terminator (promised by caller)
+    //  - cstr's content will not change before it is destroyed (by C convention)
+    let cstr: &CStr = unsafe { CStr::from_ptr(cstr) };
+    let cstring: CString = cstr.into();
+    // SAFETY:
+    //  - caller promises to free this string
+    unsafe { FzString::return_val(FzString::CString(cstring)) }
+}
+
+/// Create a new fz_string_t containing the given string with the given length. This allows creation
+/// of strings containing embedded NUL characters.  As with `fz_string_clone`, the resulting
+/// fz_string_t is independent of the passed buffer.
+///
+/// The given length should _not_ include any NUL terminator.  The given length must be less than
+/// half the maximum value of usize.
+///
+/// # Safety
+///
+/// The given pointer must not be NULL.
+///
+/// ```c
+/// fz_string_t fz_string_clone_with_len(const char *ptr, usize len);
+/// ```
+#[no_mangle]
+pub unsafe extern "C" fn fz_string_clone_with_len(buf: *const c_char, len: usize) -> fz_string_t {
+    debug_assert!(!buf.is_null());
+    debug_assert!(len < isize::MAX as usize);
+    // SAFETY:
+    //  - buf is valid for len bytes (by C convention)
+    //  - (no alignment requirements for a byte slice)
+    //  - content of buf will not be mutated during the lifetime of this slice (lifetime
+    //    does not outlive this function call)
+    //  - the length of the buffer is less than isize::MAX (promised by caller)
+    let slice = unsafe { std::slice::from_raw_parts(buf as *const u8, len) };
+
+    // allocate and copy into Rust-controlled memory
+    let vec = slice.to_vec();
+
+    // SAFETY:
+    //  - caller promises to free this string
+    unsafe { FzString::return_val(FzString::Bytes(vec)) }
+}
+
+/// Get the content of the string as a regular C string.
+///
+/// A string contianing NUL bytes will result in a NULL return value.  In general, prefer
+/// `fz_string_content_with_len` except when it's certain that the string is NUL-free.
+///
+/// The Null variant also results in a NULL return value.
+///
+/// This function takes the fz_string_t by pointer because it may be modified in-place to add a NUL
+/// terminator.  The pointer must not be NULL.
+///
+/// # Safety
+///
+/// The returned string is "borrowed" and remains valid only until the fz_string_t is freed or
+/// passed to any other API function.
+#[no_mangle]
+pub unsafe extern "C" fn fz_string_content(fzs: *mut fz_string_t) -> *const c_char {
+    // SAFETY;
+    //  - fzs is not NULL (promised by caller, verified)
+    //  - *fzs is valid (promised by caller)
+    //  - *fzs is not accessed concurrently (single-threaded)
+    unsafe {
+        FzString::with_ref_mut(fzs, |fzs| match fzs.as_cstr() {
+            // SAFETY:
+            //  - implied lifetime here is FzString's lifetime; valid until another mutable
+            //    reference is made (see docstring)
+            Ok(Some(cstr)) => cstr.as_ptr(),
+            _ => std::ptr::null(),
+        })
+    }
+}
+
+/// Get the content of the string as a pointer and length.
+///
+/// This function can return any string, even one including NUL bytes or invalid UTF-8.
+/// If the FzString is the Null variant, this returns NULl and the length is set to zero.
+///
+/// # Safety
+///
+/// The returned string is "borrowed" and remains valid only until the fz_string_t is freed or
+/// passed to any other API function.
+///
+/// ```c
+/// const char *fz_string_content_with_len(fz_string_t *, len_out *usize);
+/// ```
+#[no_mangle]
+pub unsafe extern "C" fn fz_string_content_with_len(
+    fzs: *mut fz_string_t,
+    len_out: *mut usize,
+) -> *const c_char {
+    // SAFETY;
+    //  - fzs is not NULL (promised by caller)
+    //  - *fzs is valid (promised by caller)
+    //  - *fzs is not accessed concurrently (single-threaded)
+    unsafe {
+        FzString::with_ref_mut(fzs, |fzs| {
+            let bytes = match fzs.as_bytes() {
+                Some(bytes) => bytes,
+                None => {
+                    // SAFETY:
+                    //  - len_out is not NULL (promised by caller)
+                    //  - len_out points to valid memory (promised by caller)
+                    //  - len_out is properly aligned (C convention)
+                    unsafe {
+                        *len_out = 0;
+                    }
+                    return std::ptr::null();
+                }
+            };
+
+            // SAFETY:
+            //  - len_out is not NULL (promised by caller)
+            //  - len_out points to valid memory (promised by caller)
+            //  - len_out is properly aligned (C convention)
+            unsafe {
+                *len_out = bytes.len();
+            }
+            bytes.as_ptr() as *const c_char
+        })
+    }
+}
+
+#[allow(clippy::missing_safety_doc)] // NULL pointer is OK so not actually unsafe
+/// Determine whether the given fz_string_t is a Null variant.
+///
+/// ```c
+/// bool fz_string_is_null(fz_string_t *);
+/// ```
+#[no_mangle]
+pub unsafe extern "C" fn fz_string_is_null(fzs: *const fz_string_t) -> bool {
+    unsafe { FzString::with_ref(fzs, |fzs| fzs.is_null()) }
+}
+
+/// Free a fz_string_t.
+///
+/// # Safety
+///
+/// The string must not be used after this function returns, and must not be freed more than once.
+/// It is safe to free Null-variant strings.
+///
+/// ```c
+/// fz_string_free(fz_string_t *);
+/// ```
+#[no_mangle]
+pub unsafe extern "C" fn fz_string_free(fzs: *mut fz_string_t) {
+    // SAFETY:
+    //  - fzs is not NULL (promised by caller)
+    //  - caller will not use this value after return
+    drop(unsafe { FzString::take(fzs) });
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    const INVALID_UTF8: &[u8] = b"abc\xf0\x28\x8c\x28";
+
+    #[test]
+    fn borrow() {
+        let s = CString::new("hello!").unwrap();
+        let ptr = unsafe { s.as_ptr() };
+
+        let mut fzs = unsafe { fz_string_borrow(ptr) };
+        assert!(unsafe { !fz_string_is_null(&fzs as *const fz_string_t) });
+
+        let content = unsafe { CStr::from_ptr(fz_string_content(&mut fzs as *mut fz_string_t)) };
+        assert_eq!(content.to_str().unwrap(), "hello!");
+
+        drop(s); // make sure s lasts long enough!
+
+        unsafe { fz_string_free(&mut fzs as *mut fz_string_t) };
+    }
+
+    #[test]
+    fn borrow_invalid_utf8() {
+        let s = CString::new(INVALID_UTF8).unwrap();
+        let ptr = unsafe { s.as_ptr() };
+
+        let mut fzs = unsafe { fz_string_borrow(ptr) };
+        assert!(unsafe { !fz_string_is_null(&fzs as *const fz_string_t) });
+
+        let mut len: usize = 0;
+        let ptr = unsafe {
+            fz_string_content_with_len(&mut fzs as *mut fz_string_t, &mut len as *mut usize)
+        };
+        let slice = unsafe { std::slice::from_raw_parts(ptr as *const u8, len) };
+        assert_eq!(slice, INVALID_UTF8);
+
+        drop(s); // make sure s lasts long enough!
+
+        unsafe { fz_string_free(&mut fzs as *mut fz_string_t) };
+    }
+
+    #[test]
+    fn clone() {
+        let s = CString::new("hello!").unwrap();
+        let ptr = unsafe { s.as_ptr() };
+
+        let mut fzs = unsafe { fz_string_clone(ptr) };
+        assert!(unsafe { !fz_string_is_null(&fzs as *const fz_string_t) });
+
+        drop(s); // fzs contains a clone of s, so deallocate
+
+        let content = unsafe { CStr::from_ptr(fz_string_content(&mut fzs as *mut fz_string_t)) };
+        assert_eq!(content.to_str().unwrap(), "hello!");
+
+        unsafe { fz_string_free(&mut fzs as *mut fz_string_t) };
+    }
+
+    #[test]
+    fn null_and_is_null() {
+        let mut fzs = unsafe { fz_string_null() };
+        assert!(unsafe { fz_string_is_null(&fzs as *const fz_string_t) });
+
+        unsafe { fz_string_free(&mut fzs as *mut fz_string_t) };
+    }
+
+    #[test]
+    fn null_ptr_is_null() {
+        let mut fzs = unsafe { fz_string_null() };
+        assert!(unsafe { fz_string_is_null(std::ptr::null()) });
+
+        unsafe { fz_string_free(&mut fzs as *mut fz_string_t) };
+    }
+
+    #[test]
+    fn clone_invalid_utf8() {
+        let s = CString::new(INVALID_UTF8).unwrap();
+        let ptr = unsafe { s.as_ptr() };
+
+        let mut fzs = unsafe { fz_string_clone(ptr) };
+        assert!(unsafe { !fz_string_is_null(&fzs as *const fz_string_t) });
+
+        drop(s); // fzs contains a clone of s, so deallocate
+
+        let mut len: usize = 0;
+        let ptr = unsafe {
+            fz_string_content_with_len(&mut fzs as *mut fz_string_t, &mut len as *mut usize)
+        };
+        let slice = unsafe { std::slice::from_raw_parts(ptr as *const u8, len) };
+        assert_eq!(slice, INVALID_UTF8);
+
+        unsafe { fz_string_free(&mut fzs as *mut fz_string_t) };
+    }
+
+    #[test]
+    fn clone_with_len() {
+        let s = CString::new("ABCDEFGH").unwrap();
+        let ptr = unsafe { s.as_ptr() };
+
+        let mut fzs = unsafe { fz_string_clone_with_len(ptr, 4) };
+        assert!(unsafe { !fz_string_is_null(&fzs as *const fz_string_t) });
+
+        drop(s); // fzs contains a clone of s, so deallocate
+
+        let content = unsafe { CStr::from_ptr(fz_string_content(&mut fzs as *mut fz_string_t)) };
+        assert_eq!(content.to_str().unwrap(), "ABCD"); // only 4 bytes
+
+        unsafe { fz_string_free(&mut fzs as *mut fz_string_t) };
+    }
+
+    #[test]
+    fn clone_with_len_invalid_utf8() {
+        let s = CString::new(INVALID_UTF8).unwrap();
+        let ptr = unsafe { s.as_ptr() };
+
+        let mut fzs = unsafe { fz_string_clone_with_len(ptr, 4) };
+        assert!(unsafe { !fz_string_is_null(&fzs as *const fz_string_t) });
+
+        drop(s); // fzs contains a clone of s, so deallocate
+
+        let mut len: usize = 0;
+        let ptr = unsafe {
+            fz_string_content_with_len(&mut fzs as *mut fz_string_t, &mut len as *mut usize)
+        };
+        let slice = unsafe { std::slice::from_raw_parts(ptr as *const u8, len) };
+        assert_eq!(slice, &INVALID_UTF8[..4]); // only 4 bytes
+
+        unsafe { fz_string_free(&mut fzs as *mut fz_string_t) };
+    }
+
+    // (fz_string_content's normal operation is tested above)
+
+    #[test]
+    fn content_nul_bytes() {
+        let s = String::from("hello \0 NUL byte");
+        let ptr = unsafe { s.as_ptr() } as *mut c_char;
+
+        let mut fzs = unsafe { fz_string_clone_with_len(ptr, s.len()) };
+        assert!(unsafe { !fz_string_is_null(&fzs as *const fz_string_t) });
+
+        let ptr = unsafe { fz_string_content(&mut fzs as *mut fz_string_t) };
+
+        // could not return a string because of the embedded NUL byte
+        assert!(ptr.is_null());
+
+        unsafe { fz_string_free(&mut fzs as *mut fz_string_t) };
+    }
+
+    #[test]
+    fn content_null_ptr() {
+        let ptr = unsafe { fz_string_content(std::ptr::null_mut()) };
+        assert!(ptr.is_null());
+    }
+
+    #[test]
+    fn content_with_len_nul_bytes() {
+        let s = String::from("hello \0 NUL byte");
+        let ptr = unsafe { s.as_ptr() } as *mut c_char;
+
+        let mut fzs = unsafe { fz_string_clone_with_len(ptr, s.len()) };
+        assert!(unsafe { !fz_string_is_null(&fzs as *const fz_string_t) });
+
+        let mut len: usize = 0;
+        let ptr = unsafe {
+            fz_string_content_with_len(&mut fzs as *mut fz_string_t, &mut len as *mut usize)
+        };
+
+        let slice = unsafe { std::slice::from_raw_parts(ptr as *const u8, len) };
+        let s = std::str::from_utf8(slice).unwrap();
+        assert_eq!(s, "hello \0 NUL byte");
+
+        unsafe { fz_string_free(&mut fzs as *mut fz_string_t) };
+    }
+
+    #[test]
+    fn content_with_len_null_ptr() {
+        let mut len: usize = 9999;
+        let ptr =
+            unsafe { fz_string_content_with_len(std::ptr::null_mut(), &mut len as *mut usize) };
+        assert!(ptr.is_null());
+        assert_eq!(len, 0);
+    }
+
+    // (fz_string_free is tested above)
+}


### PR DESCRIPTION
This adds a new crate, ffizz-string, which implements a simple but effective string type for passing string data between C and Rust.

It's not the fastest, but for implementing a simple library that doesn't need performance, it's adequate.