### PR TITLE
Fix unsafe OpaqueStruct::take

### DIFF
--- a/passby/examples/bytebuf.rs
+++ b/passby/examples/bytebuf.rs
@@ -34,7 +34,7 @@ pub unsafe extern "C" fn byte_buffer_init(bb: *mut byte_buffer_t) {
 /// Free a byte_buffer_t.
 #[no_mangle]
 pub unsafe extern "C" fn byte_buffer_free(bb: *mut byte_buffer_t) {
-    let bb = unsafe { ByteBuffer::take(bb) };
+    let bb = unsafe { ByteBuffer::take_ptr(bb) };
     drop(bb); // just to be explicit
 }
 
@@ -63,8 +63,8 @@ pub unsafe extern "C" fn byte_buffer_combine(
     bb1: *mut byte_buffer_t,
     bb2: *mut byte_buffer_t,
 ) -> byte_buffer_t {
-    let mut bb1 = unsafe { ByteBuffer::take(bb1) };
-    let bb2 = unsafe { ByteBuffer::take(bb2) };
+    let mut bb1 = unsafe { ByteBuffer::take_ptr(bb1) };
+    let bb2 = unsafe { ByteBuffer::take_ptr(bb2) };
 
     // modify bb1 in place (but it's not in the caller's location anymore)
     bb1.0.extend(&bb2.0[..]);

--- a/string/examples/kv.rs
+++ b/string/examples/kv.rs
@@ -177,7 +177,7 @@ pub unsafe extern "C" fn kvstore_set(
     //  - key/val are valid kvstore_string_t's (see docstring)
     //  - key/val are not accessed concurrently (type docstring)
     //  - key/val are not uesd after function returns (see docstring)
-    let (key, val) = unsafe { (FzString::take(key), FzString::take(val)) };
+    let (key, val) = unsafe { (FzString::take_ptr(key), FzString::take_ptr(val)) };
 
     if let Ok(Some(key)) = key.into_string() {
         if let Ok(Some(val)) = val.into_string() {

--- a/string/src/utilfns.rs
+++ b/string/src/utilfns.rs
@@ -206,7 +206,7 @@ pub unsafe extern "C" fn fz_string_free(fzs: *mut fz_string_t) {
     // SAFETY:
     //  - fzs is not NULL (promised by caller)
     //  - caller will not use this value after return
-    drop(unsafe { FzString::take(fzs) });
+    drop(unsafe { FzString::take_ptr(fzs) });
 }
 
 #[cfg(test)]


### PR DESCRIPTION
`OpaqueStruct::take` could be used unsafely as written.  This provides a safe option and documents when to use which.