### PR TITLE
include OpaqueStruct methods in FzString directly, with docs

### DIFF
--- a/string/examples/kv.rs
+++ b/string/examples/kv.rs
@@ -2,7 +2,7 @@
 #![allow(non_camel_case_types)]
 #![allow(unused_unsafe)]
 
-use ffizz_passby::{OpaqueStruct, PassByPointer};
+use ffizz_passby::PassByPointer;
 use ffizz_string::{fz_string_t as kvstore_string_t, FzString};
 use std::collections::HashMap;
 

--- a/string/src/utilfns.rs
+++ b/string/src/utilfns.rs
@@ -1,5 +1,4 @@
 use crate::{fz_string_t, FzString};
-use ffizz_passby::OpaqueStruct;
 use libc::c_char;
 use std::ffi::{CStr, CString};
 


### PR DESCRIPTION
This will make the methods more obvious in the docs, and also avoid requiring that `ffizz_string` users also depend on `ffizz_passby`.