### PR TITLE
add a root 'ffizz' crate

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,3 +37,7 @@ jobs:
       - run: cargo publish -p ffizz-string
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+      - run: cargo publish -p ffizz
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 
 members = [ 
+    "root",
     "header",
     "macros",
     "passby",

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,6 +1,6 @@
 # Releasing
 
-* Update version in `*/Cargo.toml`, including inter-crate version references.
+* Update version with `./update-version.sh`.
 * Commit `git commit -am vX.Y.Z`
 * Tag `git tag vX.Y.Z`
 * `git push` -- automation will do the rest

--- a/root/Cargo.toml
+++ b/root/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "ffizz"
+description = "A library of utilities for exporting Rust libs for use in other languages"
+repository = "https://github.com/djmitche/ffizz"
+readme = "../README.md"
+documentation = "https://docs.rs/ffizz"
+license = "MIT"
+version = "0.4.1"
+edition = "2021"

--- a/root/src/lib.rs
+++ b/root/src/lib.rs
@@ -1,0 +1,5 @@
+#![doc = include_str!("../../README.md")]
+//!
+//! ## This Crate
+//!
+//! This crate contains no functionality. Use the crates listed above directly.


### PR DESCRIPTION
I considered having this crate re-export symbols from the others based on features (similar to how, for example, `tokio` is just a wrapper that re-exports various `tokio-foo` crates). But for this purpose, it doesn't seem useful.